### PR TITLE
Update default API base URL to correct production address

### DIFF
--- a/.replit
+++ b/.replit
@@ -10,6 +10,8 @@ channel = "stable-25_05"
 [userenv.development]
 VITE_APP_NAME = "ZayrahLife Dev"
 VITE_ENV = "development"
+
+[userenv.shared]
 VITE_API_BASE_URL = "https://apizayrahlife.rkshaon.info"
 
 [workflows]

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,6 +1,6 @@
 import type { TokenRefreshResponse } from './types'
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://api.zayrahlife.com'
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://apizayrahlife.rkshaon.info'
 
 interface RequestConfig extends Omit<globalThis.RequestInit, 'headers'> {
   skipAuth?: boolean


### PR DESCRIPTION
Modify src/api/http.ts to change the fallback API_BASE_URL from 'https://api.zayrahlife.com' to 'https://apizayrahlife.rkshaon.info'.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 41f4e5b1-1ef2-4bfb-b692-9cba64aa6c1c
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: aacce322-71e6-4291-b486-ec76a6376da1
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/28d7bc24-d170-4552-aa9e-8eec9ed8a00e/41f4e5b1-1ef2-4bfb-b692-9cba64aa6c1c/rZEPhzI
Replit-Helium-Checkpoint-Created: true